### PR TITLE
Fix: Resolve shadowed endpoint for GET `/api/hospitals`

### DIFF
--- a/init/server.js
+++ b/init/server.js
@@ -37,33 +37,6 @@ async function connectToMongo() {
   }
 }
 
-// Get all hospitals (public route)
-app.get("/api/hospitals", async (req, res) => {
-  try {
-    const hospitals = await db.collection('hospitals').find({}, {
-      projection: {
-        name: 1,
-        bloodUnits: 1,
-        createdAt: 1,
-        updatedAt: 1
-      }
-    }).toArray();
-
-    const transformedHospitals = hospitals.map(hospital => ({
-      _id: hospital._id,
-      name: hospital.name,
-      bloodUnits: hospital.bloodUnits || {},
-      createdAt: hospital.createdAt,
-      updatedAt: hospital.updatedAt
-    }));
-
-    res.json(transformedHospitals);
-  } catch (error) {
-    console.error("Error fetching hospitals:", error);
-    res.status(500).json({ error: "Internal Server Error" });
-  }
-});
-
 // Create donation request (public route)
 app.post("/api/hospitals/:hospitalId/donation-requests", async (req, res) => {
   try {


### PR DESCRIPTION
### 📝 Description

This PR resolves a routing conflict that caused the modular hospital router to be ignored.

Because of Express's linear middleware execution, an inline public route declared in the main server file (`init/server.js`) was intercepting all incoming requests to `GET /api/hospitals`. This shadowed the root handler inside the dedicated hospital router (`init/routes/hospital.js`), turning it into dead code and fragmenting the application's routing logic.

This update removes the inline handler, delegating the routing entirely to the router module where it belongs.

### 🔗 Related Issue

Closes #3

### 💡 Changes Proposed

* Removed the redundant inline `app.get('/api/hospitals')` block from `init/server.js`.
* Ensured `app.use('/api/hospitals', hospitalRoutes)` acts as the sole entry point for hospital-related requests.
* Maintained the existing, clean root GET handler (`router.get('/')`) inside `init/routes/hospital.js`.

### ✅ Checklist

* [x] The code runs without errors locally.
* [x] The redundant server-level endpoint has been removed.
* [x] The modular router now successfully handles the `GET` request.
* [x] Code is clean and dead code has been eliminated.