### PR TITLE
fix: add Vercel rewrite configuration for client-side routing

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -2,7 +2,7 @@
   "rewrites": [
     {
       "source": "/(.*)",
-      "destination": "/index.html"
+      "destination": "/"
     }
   ]
 }

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,8 @@
+{
+  "rewrites": [
+    {
+      "source": "/(.*)",
+      "destination": "/index.html"
+    }
+  ]
+}


### PR DESCRIPTION
Summary

This PR fixes the issue where refreshing or directly accessing client-side routes results in a 404 error on the Vercel deployment.

Changes Made
Added a vercel.json configuration file.
Configured Vercel rewrite rules to redirect all client-side routes to index.html.
Ensured React Router can correctly handle route resolution after page refresh.
Problem

Routes such as:

/login
/request
Other client-side routes

worked correctly during in-app navigation but returned a Vercel 404: NOT_FOUND error when the page was refreshed or the URL was accessed directly.

Solution

Added a Vercel rewrite configuration so that all unmatched routes are served through the application's entry point (index.html), allowing React Router to manage routing on the client side.

Testing
Verified the project builds successfully.
Verified client-side routes no longer return 404 errors after refresh.
Verified direct URL access works correctly.

Closes #45 