### PR TITLE
refactor: use TanStack Query and setup centralized API base URL envir…

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,1 @@
+VITE_API_URL=http://localhost:8081

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
 node_modules
 dist
+.env
+.env.local
+.env.*.local

--- a/src/components/PeopleInNeed.tsx
+++ b/src/components/PeopleInNeed.tsx
@@ -5,6 +5,8 @@ import { usePoints } from "../contexts/PointsContext";
 import { HospitalProfile } from "@/components/HospitalProfile";
 import { DonationConfirmation } from "@/components/DonationConfirmation";
 import { Skeleton } from "@/components/ui/skeleton";
+import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
+import { API_URL } from "../config";
 
 interface Hospital {
   _id: string;
@@ -30,47 +32,43 @@ interface PeopleInNeedProps {
 export const PeopleInNeed: React.FC<PeopleInNeedProps> = ({ donorBloodGroup, userName, userId }) => {
   const { toast } = useToast();
   const { addPoints } = usePoints();
+  const queryClient = useQueryClient();
   const [donatedTo, setDonatedTo] = useState<string | null>(null);
-  const [loading, setLoading] = useState(true);
-  const [hospitals, setHospitals] = useState<Hospital[]>([]);
   const [donationUnits, setDonationUnits] = useState<number>(1);
   const [selectedHospital, setSelectedHospital] = useState<Hospital | null>(null);
   const [showOtpConfirmation, setShowOtpConfirmation] = useState(false);
   const [currentRequest, setCurrentRequest] = useState<DonationRequest | null>(null);
-  const [isCreatingRequest, setIsCreatingRequest] = useState(false);
-  const [isVerifyingOtp, setIsVerifyingOtp] = useState(false);
 
   useEffect(() => {
     window.scrollTo(0, 0);
-    fetchHospitals();
   }, [donorBloodGroup]);
 
-  const fetchHospitals = () => {
-    fetch("http://localhost:8081/api/hospitals")
-      .then((response) => {
-        if (!response.ok) {
-          throw new Error("Failed to fetch hospitals.");
-        }
-        return response.json();
-      })
-      .then((data: Hospital[]) => {
-        setHospitals(data);
-        setLoading(false);
-      })
-      .catch((error) => {
-        console.error("Error fetching hospitals:", error);
-        setLoading(false);
-        toast({
-          title: "Error",
-          description: "Failed to fetch hospitals. Please try again.",
-        });
-      });
-  };
+  // Query
+  const { data: hospitals = [], isLoading: loading, error: queryError } = useQuery<Hospital[]>({
+    queryKey: ['hospitals'],
+    queryFn: async () => {
+      const response = await fetch(`${API_URL}/api/hospitals`);
+      if (!response.ok) {
+        throw new Error("Failed to fetch hospitals.");
+      }
+      return response.json();
+    },
+  });
 
-  const createDonationRequest = async (hospital: Hospital) => {
-    setIsCreatingRequest(true);
-    try {
-      const response = await fetch(`http://localhost:8081/api/hospitals/${hospital._id}/donation-requests`, {
+  useEffect(() => {
+    if (queryError) {
+      console.error("Error fetching hospitals:", queryError);
+      toast({
+        title: "Error",
+        description: "Failed to fetch hospitals. Please try again.",
+      });
+    }
+  }, [queryError, toast]);
+
+  // Mutations
+  const createDonationRequestMutation = useMutation({
+    mutationFn: async (hospital: Hospital) => {
+      const response = await fetch(`${API_URL}/api/hospitals/${hospital._id}/donation-requests`, {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',
@@ -89,7 +87,9 @@ export const PeopleInNeed: React.FC<PeopleInNeedProps> = ({ donorBloodGroup, use
         throw new Error('Failed to create donation request');
       }
 
-      const data = await response.json();
+      return response.json();
+    },
+    onSuccess: (data) => {
       setCurrentRequest(data);
       setShowOtpConfirmation(true);
       
@@ -97,24 +97,21 @@ export const PeopleInNeed: React.FC<PeopleInNeedProps> = ({ donorBloodGroup, use
         title: "Request Created",
         description: "Please ask the hospital staff to generate an OTP for your donation.",
       });
-    } catch (error) {
+    },
+    onError: (error) => {
       console.error('Error creating donation request:', error);
       toast({
         title: "Error",
         description: "Failed to create donation request. Please try again.",
       });
-    } finally {
-      setIsCreatingRequest(false);
-    }
-  };
+    },
+  });
 
-  const handleDonate = async (otp: string) => {
-    if (!selectedHospital || !currentRequest) return;
-    setIsVerifyingOtp(true);
-
-    try {
+  const handleDonateMutation = useMutation({
+    mutationFn: async (otp: string) => {
+      if (!selectedHospital || !currentRequest) return;
       const response = await fetch(
-        `http://localhost:8081/api/hospitals/${selectedHospital._id}/verify-otp/${currentRequest._id}`,
+        `${API_URL}/api/hospitals/${selectedHospital._id}/verify-otp/${currentRequest._id}`,
         {
           method: 'POST',
           headers: {
@@ -128,6 +125,10 @@ export const PeopleInNeed: React.FC<PeopleInNeedProps> = ({ donorBloodGroup, use
         throw new Error('Invalid OTP');
       }
 
+      return response.json();
+    },
+    onSuccess: () => {
+      if (!selectedHospital) return;
       setDonatedTo(selectedHospital._id);
       const pointsEarned = 15 * donationUnits;
       addPoints(pointsEarned);
@@ -136,20 +137,21 @@ export const PeopleInNeed: React.FC<PeopleInNeedProps> = ({ donorBloodGroup, use
         description: `You've earned ${pointsEarned} points for your donation of ${donationUnits} units.`,
       });
       
-      fetchHospitals();
+      // Invalidate the hospital query to refresh the inventory
+      queryClient.invalidateQueries({ queryKey: ['hospitals'] });
+      
       setSelectedHospital(null);
       setShowOtpConfirmation(false);
       setCurrentRequest(null);
-    } catch (error) {
+    },
+    onError: (error) => {
       console.error('Error verifying donation:', error);
       toast({
         title: "Error",
         description: "Invalid OTP. Please try again.",
       });
-    } finally {
-      setIsVerifyingOtp(false);
-    }
-  };
+    },
+  });
 
   const handleHospitalClick = (hospital: Hospital) => {
     setSelectedHospital(hospital);
@@ -161,9 +163,10 @@ export const PeopleInNeed: React.FC<PeopleInNeedProps> = ({ donorBloodGroup, use
 
   const handleProfileDonate = () => {
     if (selectedHospital) {
-      createDonationRequest(selectedHospital);
+      createDonationRequestMutation.mutate(selectedHospital);
     }
   };
+
 
   if (loading) {
     return (
@@ -249,7 +252,7 @@ export const PeopleInNeed: React.FC<PeopleInNeedProps> = ({ donorBloodGroup, use
           hospital={selectedHospital}
           onClose={handleProfileClose}
           onDonate={handleProfileDonate}
-          isLoading={isCreatingRequest}
+          isLoading={createDonationRequestMutation.isPending}
         />
       )}
 
@@ -261,8 +264,8 @@ export const PeopleInNeed: React.FC<PeopleInNeedProps> = ({ donorBloodGroup, use
             setShowOtpConfirmation(false);
             setCurrentRequest(null);
           }}
-          onConfirm={handleDonate}
-          isLoading={isVerifyingOtp}
+          onConfirm={(otp) => handleDonateMutation.mutate(otp)}
+          isLoading={handleDonateMutation.isPending}
         />
       )}
     </div>

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,0 +1,1 @@
+export const API_URL = import.meta.env.VITE_API_URL || 'http://localhost:8081';

--- a/src/pages/HospitalDashboard.tsx
+++ b/src/pages/HospitalDashboard.tsx
@@ -1,8 +1,10 @@
-import React, { useState, useEffect } from 'react';
+import React, { useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { Building2, LogOut, Droplet, Clock, CheckCircle2, XCircle, Loader2 } from 'lucide-react';
 import { useToast } from "@/hooks/use-toast";
 import { Skeleton } from "@/components/ui/skeleton";
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import { API_URL } from '../config';
 
 interface BloodUnit {
   type: string;
@@ -29,74 +31,79 @@ interface DonationHistory {
 export const HospitalDashboard = () => {
   const navigate = useNavigate();
   const { toast } = useToast();
-  const [bloodInventory, setBloodInventory] = useState<BloodUnit[]>([]);
-  const [pendingRequests, setPendingRequests] = useState<DonationRequest[]>([]);
-  const [donationHistory, setDonationHistory] = useState<DonationHistory[]>([]);
-  const [loading, setLoading] = useState(true);
-  const [generatingOtpId, setGeneratingOtpId] = useState<string | null>(null);
+  const queryClient = useQueryClient();
   const hospitalName = localStorage.getItem('hospitalName') || 'Hospital';
   const hospitalToken = localStorage.getItem('hospitalToken');
 
   useEffect(() => {
     if (!hospitalToken) {
       navigate('/login');
-      return;
     }
+  }, [hospitalToken, navigate]);
 
-    fetchDashboardData();
-  }, [hospitalToken]);
-
-  const fetchDashboardData = async () => {
-    try {
-      // Fetch blood inventory
-      const inventoryResponse = await fetch('http://localhost:8081/api/hospitals/inventory', {
+  // Queries
+  const { data: bloodInventory = [], isLoading: isInventoryLoading, error: inventoryError } = useQuery<BloodUnit[]>({
+    queryKey: ['hospitalInventory', hospitalToken],
+    queryFn: async () => {
+      const response = await fetch(`${API_URL}/api/hospitals/inventory`, {
         headers: {
           'Authorization': `Bearer ${hospitalToken}`,
         },
       });
-
-      // Fetch pending requests
-      const requestsResponse = await fetch('http://localhost:8081/api/hospitals/donations/pending', {
-        headers: {
-          'Authorization': `Bearer ${hospitalToken}`,
-        },
-      });
-
-      // Fetch donation history
-      const historyResponse = await fetch('http://localhost:8081/api/hospitals/donations/history', {
-        headers: {
-          'Authorization': `Bearer ${hospitalToken}`,
-        },
-      });
-
-      if (!inventoryResponse.ok || !requestsResponse.ok || !historyResponse.ok) {
-        throw new Error('Failed to fetch dashboard data');
+      if (!response.ok) {
+        throw new Error('Failed to fetch blood inventory');
       }
+      return response.json();
+    },
+    enabled: !!hospitalToken,
+  });
 
-      const [inventory, requests, history] = await Promise.all([
-        inventoryResponse.json(),
-        requestsResponse.json(),
-        historyResponse.json(),
-      ]);
+  const { data: pendingRequests = [], isLoading: isRequestsLoading, error: requestsError } = useQuery<DonationRequest[]>({
+    queryKey: ['hospitalPendingRequests', hospitalToken],
+    queryFn: async () => {
+      const response = await fetch(`${API_URL}/api/hospitals/donations/pending`, {
+        headers: {
+          'Authorization': `Bearer ${hospitalToken}`,
+        },
+      });
+      if (!response.ok) {
+        throw new Error('Failed to fetch pending requests');
+      }
+      return response.json();
+    },
+    enabled: !!hospitalToken,
+  });
 
-      setBloodInventory(inventory);
-      setPendingRequests(requests);
-      setDonationHistory(history);
-    } catch (error) {
+  const { data: donationHistory = [], isLoading: isHistoryLoading, error: historyError } = useQuery<DonationHistory[]>({
+    queryKey: ['hospitalDonationHistory', hospitalToken],
+    queryFn: async () => {
+      const response = await fetch(`${API_URL}/api/hospitals/donations/history`, {
+        headers: {
+          'Authorization': `Bearer ${hospitalToken}`,
+        },
+      });
+      if (!response.ok) {
+        throw new Error('Failed to fetch donation history');
+      }
+      return response.json();
+    },
+    enabled: !!hospitalToken,
+  });
+
+  useEffect(() => {
+    if (inventoryError || requestsError || historyError) {
       toast({
         title: "Error",
         description: "Failed to fetch dashboard data.",
       });
-    } finally {
-      setLoading(false);
     }
-  };
+  }, [inventoryError, requestsError, historyError, toast]);
 
-  const generateOTP = async (requestId: string) => {
-    setGeneratingOtpId(requestId);
-    try {
+  // Mutations
+  const generateOtpMutation = useMutation({
+    mutationFn: async (requestId: string) => {
       const hospitalId = localStorage.getItem('hospitalId');
-      const response = await fetch(`http://localhost:8081/api/hospitals/${hospitalId}/generate-otp/${requestId}`, {
+      const response = await fetch(`${API_URL}/api/hospitals/${hospitalId}/generate-otp/${requestId}`, {
         method: 'POST',
         headers: {
           'Authorization': `Bearer ${hospitalToken}`,
@@ -108,22 +115,26 @@ export const HospitalDashboard = () => {
         throw new Error('Failed to generate OTP');
       }
 
-      const { otp } = await response.json();
+      return response.json();
+    },
+    onSuccess: (data) => {
       toast({
         title: "OTP Generated",
-        description: `OTP for verification: ${otp}`,
+        description: `OTP for verification: ${data.otp}`,
       });
-
-      fetchDashboardData();
-    } catch (error) {
+      
+      // Invalidate queries to automatically refresh lists
+      queryClient.invalidateQueries({ queryKey: ['hospitalPendingRequests'] });
+      queryClient.invalidateQueries({ queryKey: ['hospitalInventory'] });
+      queryClient.invalidateQueries({ queryKey: ['hospitalDonationHistory'] });
+    },
+    onError: () => {
       toast({
         title: "Error",
         description: "Failed to generate OTP.",
       });
-    } finally {
-      setGeneratingOtpId(null);
-    }
-  };
+    },
+  });
 
   const handleLogout = () => {
     localStorage.removeItem('hospitalToken');
@@ -131,6 +142,8 @@ export const HospitalDashboard = () => {
     localStorage.removeItem('hospitalName');
     navigate('/login');
   };
+
+  const loading = isInventoryLoading || isRequestsLoading || isHistoryLoading;
 
   if (loading) {
     return (
@@ -265,11 +278,11 @@ export const HospitalDashboard = () => {
                           </p>
                         </div>
                         <button
-                          onClick={() => generateOTP(request._id)}
-                          disabled={generatingOtpId === request._id}
+                          onClick={() => generateOtpMutation.mutate(request._id)}
+                          disabled={generateOtpMutation.isPending && generateOtpMutation.variables === request._id}
                           className="inline-flex items-center px-3 py-1 border border-transparent text-sm font-medium rounded-md text-white bg-blood hover:bg-blood-dark disabled:opacity-50 disabled:cursor-not-allowed gap-1"
                         >
-                          {generatingOtpId === request._id ? (
+                          {generateOtpMutation.isPending && generateOtpMutation.variables === request._id ? (
                             <>
                               <Loader2 className="h-4 w-4 animate-spin" />
                               Generating...

--- a/src/pages/HospitalLogin.tsx
+++ b/src/pages/HospitalLogin.tsx
@@ -1,6 +1,8 @@
 import React, { useState } from 'react';
-import { Building2, Lock } from 'lucide-react';
+import { Building2, Lock, Loader2 } from 'lucide-react';
 import { useToast } from "@/hooks/use-toast";
+import { useMutation } from '@tanstack/react-query';
+import { API_URL } from '../config';
 
 export const HospitalLogin = () => {
   const { toast } = useToast();
@@ -9,10 +11,9 @@ export const HospitalLogin = () => {
     password: '',
   });
 
-  const handleLogin = async (e: React.FormEvent) => {
-    e.preventDefault();
-    try {
-      const response = await fetch('http://localhost:8081/api/hospitals/login', {
+  const loginMutation = useMutation({
+    mutationFn: async () => {
+      const response = await fetch(`${API_URL}/api/hospitals/login`, {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',
@@ -24,18 +25,26 @@ export const HospitalLogin = () => {
         throw new Error('Login failed');
       }
 
-      const data = await response.json();
+      return response.json();
+    },
+    onSuccess: (data) => {
       localStorage.setItem('hospitalToken', data.token);
       localStorage.setItem('hospitalId', data.hospitalId);
       localStorage.setItem('hospitalName', data.name);
       
       window.location.href = '/hospital-dashboard';
-    } catch (error) {
+    },
+    onError: () => {
       toast({
         title: "Error",
         description: "Invalid credentials. Please try again.",
       });
-    }
+    },
+  });
+
+  const handleLogin = (e: React.FormEvent) => {
+    e.preventDefault();
+    loginMutation.mutate();
   };
 
   return (
@@ -95,12 +104,22 @@ export const HospitalLogin = () => {
           <div>
             <button
               type="submit"
-              className="group relative w-full flex justify-center py-2 px-4 border border-transparent text-sm font-medium rounded-md text-white bg-blood hover:bg-blood-dark focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blood"
+              disabled={loginMutation.isPending}
+              className="group relative w-full flex justify-center py-2 px-4 border border-transparent text-sm font-medium rounded-md text-white bg-blood hover:bg-blood-dark focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blood disabled:opacity-50 disabled:cursor-not-allowed"
             >
-              <span className="absolute left-0 inset-y-0 flex items-center pl-3">
-                <Lock className="h-5 w-5 text-blood-dark group-hover:text-blood" />
-              </span>
-              Sign in
+              {loginMutation.isPending ? (
+                <>
+                  <Loader2 className="h-5 w-5 mr-2 animate-spin" />
+                  Signing in...
+                </>
+              ) : (
+                <>
+                  <span className="absolute left-0 inset-y-0 flex items-center pl-3">
+                    <Lock className="h-5 w-5 text-blood-dark group-hover:text-blood" />
+                  </span>
+                  Sign in
+                </>
+              )}
             </button>
           </div>
         </form>

--- a/src/pages/Login.tsx
+++ b/src/pages/Login.tsx
@@ -2,6 +2,7 @@ import React, { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { Heart, Building2, User, ArrowRight } from 'lucide-react';
 import { useToast } from "@/hooks/use-toast";
+import { API_URL } from '../config';
 
 export const Login = () => {
   const navigate = useNavigate();
@@ -15,7 +16,7 @@ export const Login = () => {
   const handleHospitalLogin = async (e: React.FormEvent) => {
     e.preventDefault();
     try {
-      const response = await fetch('http://localhost:8081/api/hospitals/login', {
+      const response = await fetch(`${API_URL}/api/hospitals/login`, {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',


### PR DESCRIPTION
Closes #43 
## Changes
- **Centralized API Config**:
  - Created `src/config.ts` exporting `API_URL` (reads `import.meta.env.VITE_API_URL` with a fallback to `http://localhost:8081`).
  - Added `.env` and `.env.example` templates.
  - Updated `.gitignore` to prevent committing local `.env` files.
  - Replaced all hardcoded API URL strings with the imported `API_URL`.
- **HospitalDashboard.tsx**:
  - Replaced parallel manual fetch calls (`/inventory`, `/donations/pending`, `/donations/history`) with `useQuery`.
  - Wrapped `generateOTP` fetch in a `useMutation` hook.
  - Automatically invalidates queries on successful mutation to keep inventory and history in sync.
- **PeopleInNeed.tsx**:
  - Replaced hospital fetch with `useQuery`.
  - Replaced `createDonationRequest` and `handleDonate` with `useMutation`.
  - Handled error toast notifications gracefully via TanStack Query's `onError` callbacks.
  - Invalidates `hospitals` query on successful donation to refresh inventory details.
- **HospitalLogin.tsx**:
  - Wrapped the login request in a `useMutation`.
  - Added a loading spinner and disabled state to the login button during pending requests.
## Verification
- Run `npm run test:run` (all 22 unit tests passed).
- Checked production build output with `npm run build` (build completed successfully with no compilation/type errors).